### PR TITLE
Replaced a string reference by a string pointer and cleaned up previously leaked memory

### DIFF
--- a/2-parsers/include/ast/ast_primitives.hpp
+++ b/2-parsers/include/ast/ast_primitives.hpp
@@ -10,9 +10,9 @@ class Variable
 private:
     std::string id;
 public:
-    Variable(const std::string &_id)
-        : id(_id)
-    {}
+    Variable(const std::string *_id)
+        : id(*_id)
+    { delete _id; }
 
     const std::string getId() const
     { return id; }


### PR DESCRIPTION
Title.
Alternatives are:
- use a string pointer in the class, which is kind of bad because a string is already basically a pointer (with added data)
- use unique_ptr / shared_ptr as in lab3, but this introduces smart pointer complexity too soon IMO