### PR TITLE
add division lexing

### DIFF
--- a/2-parsers/src/maths_lexer.flex
+++ b/2-parsers/src/maths_lexer.flex
@@ -9,6 +9,7 @@ extern "C" int fileno(FILE *stream);
 
 %%
 [*]             { return T_TIMES; }
+[/]             { return T_DIVIDE; }
 [+]             { return T_PLUS; }
 [\^]            { return T_EXPONENT; }
 [-]             { return T_MINUS; }


### PR DESCRIPTION
Added the missing lexing for the division symbol.

This was causing a bug, Quentin debugged it, I'm adding the fix here.