### PR TITLE
Remove return type from `step`

### DIFF
--- a/3-codegen/src/vm.cpp
+++ b/3-codegen/src/vm.cpp
@@ -74,7 +74,7 @@ public:
         pc=it->second;
     }
 
-    bool step()
+    void step()
     {
         if(pc >= instructions.size() ){
             throw std::runtime_error("step : pc has exceeded number of instructions.");


### PR DESCRIPTION
Lack of return was causing crash in the VM. Occurs on g++ version 13 or greater, seems to be linked to this bug report <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104642> where `-funreachable-trap` was enabled by default for debug builds.
Wasn't used anywhere and had no immediate clear meaning (as all failures throw errors) so seemed easier than returning a value. 